### PR TITLE
ci: Add merge conflict labeler workflow

### DIFF
--- a/.github/workflows/merge-conflict-auto-label.yml.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml.yml
@@ -1,0 +1,18 @@
+name: Merge Conflict Auto Label
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "10 21 * * *"
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mschilde/auto-label-merge-conflicts@master
+        with:
+          CONFLICT_LABEL_NAME: "merge conflicts"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAX_RETRIES: 5
+          WAIT_MS: 5000

--- a/.github/workflows/merge-conflict-auto-label.yml.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml.yml
@@ -1,5 +1,6 @@
 name: Merge Conflict Auto Label
 on:
+  workflow_dispatch: # Manual run
   push:
     branches:
       - main

--- a/.github/workflows/merge-conflict-auto-label.yml.yml
+++ b/.github/workflows/merge-conflict-auto-label.yml.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   schedule:
-    - cron: "10 21 * * *"
+    - cron: "10 21 * * *" # Runs at 21:10; time was chosen based on contributor activity and low GitHub Actions cron load.
 
 jobs:
   triage:


### PR DESCRIPTION
This adds a GitHub Action workflow that runs `mschilde/auto-label-merge-conflicts` once a day. As this repo (`.github`) is a special repository this will result on the action to be run on all Northstar repositories.

I expect at least some of our current ones to not have the `merge conflict` label and as such the workflow failing on those repo but that can be remedied by adding the label if we notice a workflow failing somewhere.
